### PR TITLE
bugfix on logging

### DIFF
--- a/syms2elf.py
+++ b/syms2elf.py
@@ -669,8 +669,8 @@ def write_symbols(input_file, output_file, symbols):
                 "other" : 0,
                 "shndx" : sh_idx
             }
-
-            #log("0x%08x - 0x%08x - %s - %d/%d - %d" % (s.value, s.size, s.name, strtab_raw.index(s.name), len(strtab_raw), s.info))
+            
+            log("0x%08x - 0x%08x - %s - %d/%d - %d" % (s.value, s.size, s.name, strtab_raw.index(bytes(s.name.encode('ascii'))), len(strtab_raw), s.info))
             bin.append_symbol(sym)
 
         # add symbol strings
@@ -680,6 +680,7 @@ def write_symbols(input_file, output_file, symbols):
         bin.save(output_file)
 
     except:
+        import traceback
         log(traceback.format_exc())
 
 def ida_fcn_filter(func_ea):


### PR DESCRIPTION
673 is a commented line that could break the program with an exception because s.name is a string, not a bytes object, which was expected by strtab_raw.index()

also, exceptions were logged with traceback without importing it before

these problems I attempted to solve herein. Check if they are suitable.

greetings!